### PR TITLE
Fix CORS/Cookie issues now that we're issuing server-side cookies

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -16,6 +16,10 @@ class Config:
     FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:5173")
     logger.info(f"FRONTEND_URL set to: {FRONTEND_URL}")
     
+    # Get backend domain for cookie setting
+    BACKEND_DOMAIN = os.environ.get("BACKEND_DOMAIN", "localhost" if not IS_PRODUCTION else None)
+    logger.info(f"BACKEND_DOMAIN set to: {BACKEND_DOMAIN}")
+    
     # Allow the frontend URL and localhost for development
     ALLOWED_ORIGINS: List[str] = [
         FRONTEND_URL,

--- a/backend/main.py
+++ b/backend/main.py
@@ -42,10 +42,10 @@ def set_player_id_cookie(response: Response, player_id: str) -> None:
         value=player_id,
         max_age=365 * 24 * 60 * 60,  # 1 year
         httponly=True,
-        samesite="lax",  # Change from strict to lax for development
+        samesite="lax",  # Allow cross-site requests while maintaining security
         secure=config.IS_PRODUCTION,  # Only set secure in production
         path="/",
-        domain=None  # Let the browser set the appropriate domain
+        domain=config.BACKEND_DOMAIN  # Set to backend domain explicitly
     )
 
 # Auth endpoints
@@ -86,7 +86,8 @@ def logout(response: Response):
         httponly=True,
         samesite="lax",
         path="/",
-        secure=config.IS_PRODUCTION
+        secure=config.IS_PRODUCTION,
+        domain=config.BACKEND_DOMAIN
     )
     return {"message": "Logged out successfully"}
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -42,7 +42,7 @@ def set_player_id_cookie(response: Response, player_id: str) -> None:
         value=player_id,
         max_age=365 * 24 * 60 * 60,  # 1 year
         httponly=True,
-        samesite="lax",  # Allow cross-site requests while maintaining security
+        samesite="none",
         secure=config.IS_PRODUCTION,  # Only set secure in production
         path="/",
         domain=config.BACKEND_DOMAIN  # Set to backend domain explicitly
@@ -84,7 +84,7 @@ def logout(response: Response):
     response.delete_cookie(
         key="playerId",
         httponly=True,
-        samesite="lax",
+        samesite="none",
         path="/",
         secure=config.IS_PRODUCTION,
         domain=config.BACKEND_DOMAIN


### PR DESCRIPTION
Had a bunch of red herrings here, but now working at least a bit in prod.

Ultimately key was:

* HTTPS is required
* Samesite is "none" the string not None the python value
* ENV variable specifying domain should be just the hostname of the backend/API, no HTTPS:// prefix

